### PR TITLE
Use Python 3 to build the documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM ubuntu:18.04
 
-RUN apt-get update -qqy && \
-    apt-get install -qqy python-virtualenv python-pip rpm && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    pip install -q Sphinx==1.7.9 sphinxcontrib-phpdomain
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates python3-pip python3-setuptools rpm make file && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/bin/pip3 /usr/bin/pip && \
+    pip install -q virtualenv==16.7.5 Sphinx==1.7.9
 
 ENV VERSION 1
 


### PR DESCRIPTION
The symlink form pip3 to pip is needed to support building the current and previous
version of the Tuleap documentation.